### PR TITLE
Add tags plugin and clean up navigation

### DIFF
--- a/docs/campaigns/archive/bastion/index.md
+++ b/docs/campaigns/archive/bastion/index.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - campaigns
+  - archive
+  - bastion
+---
+
 # Bastion: The Last City
 
 Campaign materials for the Bastion setting.

--- a/docs/campaigns/archive/index.md
+++ b/docs/campaigns/archive/index.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - campaigns
+  - archive
+---
+
 # Campaign Archive
 
 Completed and past campaign materials organized by setting and era.

--- a/docs/campaigns/archive/sessions/index.md
+++ b/docs/campaigns/archive/sessions/index.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - campaigns
+  - archive
+  - sessions
+---
+
 # Session Archive
 
 Historical session notes and logs.

--- a/docs/campaigns/archive/taldorei/index.md
+++ b/docs/campaigns/archive/taldorei/index.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - campaigns
+  - archive
+  - taldorei
+---
+
 # Taldorei Campaign
 
 Campaign materials for the Taldorei setting.

--- a/docs/campaigns/archive/tyranny-of-dragons/index.md
+++ b/docs/campaigns/archive/tyranny-of-dragons/index.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - campaigns
+  - archive
+  - tyranny-of-dragons
+---
+
 # Tyranny of Dragons
 
 Campaign materials for the Tyranny of Dragons campaign.

--- a/docs/campaigns/index.md
+++ b/docs/campaigns/index.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - campaigns
+---
+
 # Campaigns
 
 Campaign materials and archives from D&D games.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - home
+---
+
 # Dungeons and Dragons
 This is a repository I use to keep notes on games I am part of or am currently running. If you are part of my Dungeons and Dragons games, I kindly ask that you proceed no further. If you do... there is no telling what may happen to your character.
 

--- a/docs/planning/future-campaigns/index.md
+++ b/docs/planning/future-campaigns/index.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - planning
+  - future-campaigns
+---
+
 # Future Campaign Ideas
 
 Concepts and plans for upcoming campaigns.

--- a/docs/planning/future-campaigns/stormreach/campaign_3_planner.md
+++ b/docs/planning/future-campaigns/stormreach/campaign_3_planner.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - planning
+  - future-campaigns
+  - stormreach
+---
+
 <!-- TOC START min:1 max:3 link:true update:true -->
 - [War-torn: Steel and Shadows](#war-torn-steel-and-shadows)
   - [The World](#the-world)

--- a/docs/planning/future-campaigns/stormreach/campaign_ideas.md
+++ b/docs/planning/future-campaigns/stormreach/campaign_ideas.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - planning
+  - future-campaigns
+  - stormreach
+---
+
 <!-- TOC START min:1 max:3 link:true update:true -->
 - [Additional Campaign 3 Ideas](#additional-campaign-3-ideas)
   - [Breland Adventure](#breland-adventure)

--- a/docs/planning/future-campaigns/stormreach/for_the_players.md
+++ b/docs/planning/future-campaigns/stormreach/for_the_players.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - planning
+  - future-campaigns
+  - stormreach
+---
+
 <!-- TOC START min:1 max:3 link:true update:true -->
 - [Stormreach](#stormreach)
   - [Character Information](#character-information)

--- a/docs/planning/templates/index.md
+++ b/docs/planning/templates/index.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - planning
+  - templates
+---
+
 # Session & Campaign Templates
 
 Reusable templates for planning and organization.

--- a/docs/planning/templates/session_template.md
+++ b/docs/planning/templates/session_template.md
@@ -2,5 +2,8 @@
 title: "Session_template"
 date: 2019-08-04T03:24:39-04:00
 draft: true
+tags:
+  - planning
+  - templates
 ---
 

--- a/docs/planning/utilities/dungeon_001.md
+++ b/docs/planning/utilities/dungeon_001.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - planning
+  - utilities
+  - dungeon
+---
+
 # Dungeon 001
 
 ### Entrance

--- a/docs/planning/utilities/index.md
+++ b/docs/planning/utilities/index.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - planning
+  - utilities
+---
+
 # Planning Utilities
 
 Tools and resources for campaign and adventure preparation.

--- a/docs/resources/dm_screen.md
+++ b/docs/resources/dm_screen.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - resources
+  - dm-screen
+---
+
 <!-- vim-markdown-toc GFM -->
 
 * [Actions (2024 Rules)](#actions-2024-rules)

--- a/docs/resources/rules.md
+++ b/docs/resources/rules.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - resources
+  - rules
+---
+
 # Rules Reference
 
 This document contains both the official 2024 D&D Rules Glossary and custom house rules used in campaigns.
@@ -5,7 +11,7 @@ This document contains both the official 2024 D&D Rules Glossary and custom hous
 <!-- vim-markdown-toc GFM -->
 
 * [Rules Glossary (2024 PHB)](#rules-glossary-2024-phb)
-* [House Rules & Mechanics](#house-rules--mechanics)
+* [House Rules & Mechanics](#house-rules-mechanics)
     * [Combat Rules](#combat-rules)
         * [Spell Damage](#spell-damage)
         * [Casting Spells](#casting-spells)
@@ -19,7 +25,7 @@ This document contains both the official 2024 D&D Rules Glossary and custom hous
         * [Hit Dice Recovery](#hit-dice-recovery)
     * [Skill Checks](#skill-checks)
         * [Critical Failures and Success](#critical-failures-and-success)
-    * [Conditions & Effects](#conditions--effects)
+    * [Conditions & Effects](#conditions-effects)
         * [Drunkenness](#drunkenness)
         * [Poisoning](#poisoning)
             * [Poison Types](#poison-types)

--- a/docs/resources/tips.md
+++ b/docs/resources/tips.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - resources
+  - tips
+---
+
 # GM Tips & Best Practices
 
 Guidance and tips for running effective D&D games.

--- a/docs/resources/tools/experience.md
+++ b/docs/resources/tools/experience.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - resources
+  - tools
+  - experience
+---
+
 <!-- vim-markdown-toc GFM -->
 
 * [Three Pillar Experience (Current System)](#three-pillar-experience-current-system)

--- a/docs/resources/tools/index.md
+++ b/docs/resources/tools/index.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - resources
+  - tools
+---
+
 # GM Tools & Utilities
 
 Practical tools and references for running games.

--- a/docs/resources/tools/npc_names.md
+++ b/docs/resources/tools/npc_names.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - resources
+  - tools
+  - npc
+---
+
 ## Male Names
 
 - Brando Di Giulio

--- a/docs/resources/worldbuilding.md
+++ b/docs/resources/worldbuilding.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - resources
+  - worldbuilding
+---
+
 # Worldbuilding Resources
 
 Setting elements, locations, and reference materials for creating immersive campaign worlds.
@@ -10,11 +16,11 @@ Setting elements, locations, and reference materials for creating immersive camp
     * [City Services](#city-services)
 * [Adventure Locations](#adventure-locations)
     * [Dungeon Settings](#dungeon-settings)
-    * [Tavern Goods & Services](#tavern-goods--services)
+    * [Tavern Goods & Services](#tavern-goods-services)
     * [Traps](#traps)
         * [Save DCs and Attack Bonuses](#save-dcs-and-attack-bonuses)
         * [Damage Severity by Level](#damage-severity-by-level)
-* [Travel & Exploration](#travel--exploration)
+* [Travel & Exploration](#travel-exploration)
     * [Travel Pace](#travel-pace)
 
 <!-- vim-markdown-toc -->

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,5 @@
+---
+title: Tags
+---
+
+# Tags

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ theme:
   favicon: assets/dnd-ampersand.png
 extra_css:
   - stylesheets/dnd-theme.css
+plugins:
+  - search
+  - tags
 nav:
   - Home: index.md
   - Campaigns:
@@ -30,10 +33,10 @@ nav:
     - Rules: resources/rules.md
     - Worldbuilding: resources/worldbuilding.md
     - DM Screen: resources/dm_screen.md
-    - DM Screen (Legacy): resources/dm_screen_legacy.md
     - Tools: resources/tools/index.md
     - Tips: resources/tips.md
   - Planning:
     - Templates: planning/templates/index.md
     - Future Campaigns: planning/future-campaigns/index.md
     - Utilities: planning/utilities/index.md
+  - Tags: tags.md


### PR DESCRIPTION
## Summary
- remove legacy DM screen link and enable tags plugin
- tag documentation pages for campaigns, planning and resources
- fix internal anchors and add tags page

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6892a905f0208325a3555af8dc3639d1