### PR TITLE
Add Copier templates for posts and session notes

### DIFF
--- a/copier_templates/README.md
+++ b/copier_templates/README.md
@@ -1,0 +1,19 @@
+# Copier Templates
+
+This directory contains [Copier](https://copier.readthedocs.io/) templates that help generate new content for the notes site.
+
+## New Blog Post
+
+```
+copier copy copier_templates/post docs/blog/posts
+```
+
+You will be prompted for the post information. The new file will be created in `docs/blog/posts/` with the name you provide.
+
+## New Session Notes
+
+```
+copier copy copier_templates/session path/to/campaign
+```
+
+Replace `path/to/campaign` with the directory where the session file should live (for example `archive/campaigns/bastion`).

--- a/copier_templates/post/copier.yml
+++ b/copier_templates/post/copier.yml
@@ -1,0 +1,27 @@
+_subdirectory: .
+
+# Questions
+slug:
+  type: str
+  help: "Filename for the post (without extension)"
+  default: "new-post"
+
+title:
+  type: str
+  help: "Title of the post"
+  default: "New Post"
+
+date:
+  type: str
+  help: "Date of the post"
+  default: "{{ '%Y-%m-%d' | format(now()) }}"
+
+tags:
+  type: str
+  help: "Comma separated list of tags"
+  default: ""
+
+summary:
+  type: str
+  help: "Short summary for the post"
+  default: ""

--- a/copier_templates/post/{{ slug }}.md.jinja
+++ b/copier_templates/post/{{ slug }}.md.jinja
@@ -1,0 +1,12 @@
+---
+title: {{ title }}
+date: {{ date }}
+{% if tags %}tags: [{{ tags|replace(' ', '') }}]
+{% else %}tags: []
+{% endif %}
+summary: {{ summary }}
+---
+
+# {{ title }}
+
+<!-- Your content starts here -->

--- a/copier_templates/session/copier.yml
+++ b/copier_templates/session/copier.yml
@@ -1,0 +1,16 @@
+_subdirectory: .
+
+slug:
+  type: str
+  help: "Filename for the session (e.g. 001)"
+  default: "001"
+
+title:
+  type: str
+  help: "Title of the session"
+  default: "Session Title"
+
+date:
+  type: str
+  help: "Date of the session"
+  default: "{{ now().isoformat() }}"

--- a/copier_templates/session/{{ slug }}.md.jinja
+++ b/copier_templates/session/{{ slug }}.md.jinja
@@ -1,0 +1,32 @@
+---
+title: "{{ title }}"
+date: {{ date }}
+---
+
+## Who are the characters?
+
+- 
+
+## What is the strong start?
+
+- 
+
+## What scenes might take place?
+
+- 
+
+## What secrets and clues might the characters uncover?
+
+- 
+
+## What fantastic locations might they explore?
+
+- 
+
+## What NPCs might they meet?
+
+- 
+
+## What magic items might they acquire?
+
+- 


### PR DESCRIPTION
## Summary
- add Copier templates for blog posts
- add Copier templates for session planning notes
- document how to generate files with Copier

## Testing
- `pip install mkdocs-macros-plugin` *(fails: Could not find a version that satisfies the requirement mkdocs-macros-plugin)*
- `make build` *(fails: Config value 'plugins': The "macros" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6892ccbee7dc83259ab2e765e7c09fdd