### PR TITLE
Add tag-based browsing for posts

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,6 @@
+---
+title: Tags
+---
+
+# Tags
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,8 @@ markdown_extensions:
   - pymdownx.superfences
 plugins:
   - search
-  - tags
+  - tags:
+      tags_file: tags.md
   - blog:
       blog_dir: .
       categories_name: Topics
@@ -33,6 +34,7 @@ plugins:
       include_dir: .
 nav:
   - Session Notes: index.md
+  - Tags: tags.md
   - Resources:
       - NPC Names: resources/npc_names.md
       - DM Screen: resources/dm_screen.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 mkdocs
 mkdocs-material
+mkdocs-blog-plugin
+mkdocs-macros-plugin


### PR DESCRIPTION
## Summary
- configure tags plugin and expose tag index in navigation
- add blog and macros plugins to dependencies
- create landing page for browsing by tag

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6892d4a92cdc83259a7e26bfd0dcf98c