### PR TITLE
Add downtime activities reference

### DIFF
--- a/docs/resources/downtime.md
+++ b/docs/resources/downtime.md
@@ -1,0 +1,357 @@
+---
+tags:
+  - resources
+  - downtime
+---
+
+# Downtime Activities
+
+Reference of downtime activities from *Xanathar's Guide to Everything*.
+
+<!-- TOC -->
+- [Buying a Magic Item](#buying-a-magic-item)
+- [Carousing](#carousing)
+- [Crafting an Item](#crafting-an-item)
+- [Crime](#crime)
+- [Gambling](#gambling)
+- [Pit Fighting](#pit-fighting)
+- [Relaxation](#relaxation)
+- [Religious Service](#religious-service)
+- [Research](#research)
+- [Scribing a Spell Scroll](#scribing-a-spell-scroll)
+- [Selling a Magic Item](#selling-a-magic-item)
+- [Training](#training)
+- [Work](#work)
+<!-- TOC END -->
+
+## Buying a Magic Item
+Each search for a magic item requires 1 workweek of downtime and 100 gp spent on gifts and rumors. At the end of the week, make a Charisma (Persuasion) check to see what sellers have. Spending additional workweeks or 100 gp grants a +1 bonus to the check, up to +10. The result determines which magic item tables to roll on and each item’s price. Complications might arise while negotiating the deal.
+### Buying Magic Items
+| Check Total | Items Acquired |
+| --- | --- |
+| 1—5 | Roll 1d6 times on Magic Item Table A. |
+| 6—10 | Roll 1d4 times on Magic Item Table B. |
+| 11—15 | Roll 1d4 times on Magic Item Table C. |
+| 16—20 | Roll 1d4 times on Magic Item Table D. |
+| 21—25 | Roll 1d4 times on Magic Item Table E. |
+| 26—30 | Roll 1d4 times on Magic Item Table F. |
+| 31—35 | Roll 1d4 times on Magic Item Table G. |
+| 36—40 | Roll 1d4 times on Magic Item Table H. |
+| 41+ | Roll 1d4 times on Magic Item Table I. |
+### Magic Item Price
+| Rarity | Asking Price* |
+| --- | --- |
+| Common | (1d6 + 1) × 10 gp |
+| Uncommon | 1d6 × 100 gp |
+| Rare | 2d10 × 1,000 gp |
+| Very rare | (1d4 + 1) × 10,000 gp |
+| Legendary | 2d6 × 25,000 gp |
+
+**Halved for a consumable item like a potion or scroll*
+### Magic Item Purchase Complications
+| d12 | Complication |
+| --- | --- |
+| 1 | The item is a fake, planted by an enemy.* |
+| 2 | The item is stolen by the party's enemies.* |
+| 3 | The item is cursed by a god. |
+| 4 | The item's original owner will kill to reclaim it; the party's enemies spread news of its sale.* |
+| 5 | The item is at the center of a dark prophecy. |
+| 6 | The seller is murdered before the sale.* |
+| 7 | The seller is a devil looking to make a bargain. |
+| 8 | The item is the key to freeing an evil entity. |
+| 9 | A third party bids on the item, doubling its price.* |
+| 10 | The item is an enslaved, intelligent entity. |
+| 11 | The item is tied to a cult. |
+| 12 | The party's enemies spread rumors that the item is an artifact of evil.* |
+
+**Might involve a rival*
+
+## Carousing
+You mingle with the locals for a week of revelry. Choose a social class—lower, middle, or upper—and pay the related expenses (10 gp, 50 gp, or 250 gp). At week’s end, make a Charisma (Persuasion) check with the DC determined by the chosen class (10, 15, or 20). Every additional 10 gp spent grants a +1 bonus. The check result reveals how many useful contacts you made and whether any trouble found you.
+### Carousing
+| Check Total | Result |
+| --- | --- |
+| 1—5 | Character has made a hostile contact. |
+| 6—10 | Character has made no new contacts. |
+| 11—15 | Character has made an allied contact. |
+| 16—20 | Character has made two allied contacts. |
+| 21+ | Character has made three allied contacts. |
+### Lower-Class Carousing Complications
+| d8 | Complication |
+| --- | --- |
+| 1 | A pickpocket lifts 1d10 × 5 gp from you.* |
+| 2 | A bar brawl leaves you with a scar.* |
+| 3 | You have fuzzy memories of doing something very, very illegal, but can't remember exactly what. |
+| 4 | You are banned from a tavern after some obnoxious behavior.* |
+| 5 | After a few drinks, you swore in the town square to pursue a dangerous quest. |
+| 6 | Surprise! You're married. |
+| 7 | Streaking naked through the streets seemed like a great idea at the time. |
+| 8 | Everyone is calling you by some weird, embarrassing nickname, like Puddle Drinker or Bench Slayer, and no one will say why.* |
+
+**Might involve a rival*
+### Middle-Class Carousing Complications
+| d8 | Complication |
+| --- | --- |
+| 1 | You accidentally insulted a guild master, and only a public apology will let you do business with the guild again.* |
+| 2 | You swore to complete some quest on behalf of a temple or a guild. |
+| 3 | A social gaffe has made you the talk of the town.* |
+| 4 | A particularly obnoxious person has taken an intense romantic interest in you.* |
+| 5 | You have made a foe out of a local spellcaster.* |
+| 6 | You have been recruited to help run a local festival, play, or similar event. |
+| 7 | You made a drunken toast that scandalized the locals. |
+| 8 | You spent an additional 100 gp trying to impress people. |
+
+**Might involve a rival*
+### Upper-Class Carousing Complications
+| d8 | Complication |
+| --- | --- |
+| 1 | A pushy noble family wants to marry off one of their scions to you.* |
+| 2 | You tripped and fell during a dance, and people can't stop talking about it. |
+| 3 | You have agreed to take on a noble's debts. |
+| 4 | You have been challenged to a joust by a knight.* |
+| 5 | You have made a foe out of a local noble.* |
+| 6 | A boring noble insists you visit each day and listen to long, tedious theories of magic. |
+| 7 | You have become the target of a variety of embarrassing rumors.* |
+| 8 | You spent an additional 500 gp trying to impress people. |
+
+**Might involve a rival*
+
+## Crafting an Item
+To craft nonmagical gear, you must possess the relevant tool proficiency and materials worth half the item’s market price. Each workweek of downtime lets you make progress worth 25 gp, divided among any items you choose. Magic item crafting also requires a formula and special ingredients. The item’s rarity sets the time and gold needed, and failed progress can spawn complications. Brewing potions of healing uses the same rules with its own time and cost table.
+### Magic Item Ingredients
+| Item Rarity | CR Range |
+| --- | --- |
+| Common | 1—3 |
+| Uncommon | 4—8 |
+| Rare | 9—12 |
+| Very rare | 13—18 |
+| Legendary | 19+ |
+### Magic Item Crafting Time and Cost
+| Item Rarity | Workweeks* | Cost* |
+| --- | --- | --- |
+| Common | 1 | 50 gp |
+| Uncommon | 2 | 200 gp |
+| Rare | 10 | 2,000 gp |
+| Very rare | 25 | 20,000 gp |
+| Legendary | 50 | 100,000 gp |
+
+**Halved for a consumable item like a potion or scroll*
+### Crafting Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | Rumors swirl that what you're working on is unstable and a threat to the community.* |
+| 2 | Your tools are stolen, forcing you to buy new ones.* |
+| 3 | A local wizard shows keen interest in your work and insists on observing you. |
+| 4 | A powerful noble offers a hefty price for your work and is not interested in hearing no for an answer.* |
+| 5 | A dwarf clan accuses you of stealing its secret lore to fuel your work.* |
+| 6 | A competitor spreads rumors that your work is shoddy and prone to failure.* |
+
+**Might involve a rival*
+### Potion of Healing Creation
+| Type | Time | Cost |
+| --- | --- | --- |
+| Healing | 1 day | 25 gp |
+| Greater healing | 1 workweek | 100 gp |
+| Superior healing | 3 workweeks | 1,000 gp |
+| Supreme healing | 4 workweeks | 10,000 gp |
+
+## Crime
+Plotting a crime takes 1 workweek and 25 gp in bribes and supplies. Choose a target DC from the Loot Value table, then make three checks: Dexterity (Stealth), Dexterity using thieves’ tools, and your choice of Intelligence (Investigation) or Charisma (Deception). Each check uses the chosen DC. Two or more successes mean the job pays off; fewer successes risk capture or other consequences as determined by the DM.
+### Loot Value
+| DC | Value |
+| --- | --- |
+| 10 | 50 gp, robbery of a struggling merchant |
+| 15 | 100 gp, robbery of a prosperous merchant |
+| 20 | 200 gp, robbery of a noble |
+| 25 | 1,000 gp, robbery of one of the richest figures in town |
+### Crime Complications
+| d8 | Complication |
+| --- | --- |
+| 1 | A bounty equal to your earnings is offered for information about your crime.* |
+| 2 | An unknown person contacts you, threatening to reveal your crime if you don't render a service.* |
+| 3 | Your victim is financially ruined by your crime. |
+| 4 | Someone who knows of your crime has been arrested on an unrelated matter.* |
+| 5 | Your loot is a single, easily identified item that you can't fence in this region. |
+| 6 | You robbed someone who was under a local crime lord's protection, and who now wants revenge. |
+| 7 | Your victim calls in a favor from a guard, doubling the efforts to solve the case. |
+| 8 | Your victim asks one of your adventuring companions to solve the crime. |
+
+**Might involve a rival*
+
+## Gambling
+You wager at least 100 gp on a week of games. Make three checks—Wisdom (Insight), Charisma (Deception), and Charisma (Intimidation)—against a DC set by the quality of the competition (typically 15). Tally the number of successes to determine winnings or losses and any complications from your time at the tables.
+### Gambling Results
+| Result | Value |
+| --- | --- |
+| 0 successes | Lose all the money you bet, and accrue a debt equal to that amount. |
+| 1 success | Lose half the money you bet. |
+| 2 successes | Gain the amount you bet plus half again more. |
+| 3 successes | Gain double the amount you bet. |
+### Gambling Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | You are accused of cheating. You decide whether you actually did cheat or were framed.* |
+| 2 | The town guards raid the gambling hall and throw you in jail.* |
+| 3 | A noble in town loses badly to you and loudly vows to get revenge.* |
+| 4 | You won a sum from a low-ranking member of a thieves' guild, and the guild wants its money back. |
+| 5 | A local crime boss insists you start frequenting the boss's gambling parlor and no others. |
+| 6 | A high-stakes gambler comes to town and insists that you take part in a game. |
+
+**Might involve a rival*
+
+## Pit Fighting
+Fighting pits offer coin to those who survive a week of bouts. Over the workweek make three checks: Strength (Athletics), Dexterity (Acrobatics), and a Constitution saving throw against a DC set by the local talent (usually 15). Count the successes to see your total winnings and whether any rivals or injuries trouble you.
+### Pit Fighting Results
+| Result | Value |
+| --- | --- |
+| 0 successes | Lose your bouts, earning nothing. |
+| 1 success | Win 50 gp. |
+| 2 successes | Win 100 gp. |
+| 3 successes | Win 200 gp. |
+### Pit Fighting Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | An opponent swears to take revenge on you.* |
+| 2 | A crime boss approaches you and offers to pay you to intentionally lose a few matches.* |
+| 3 | You defeat a popular local champion, drawing the crowd's ire. |
+| 4 | You defeat a noble's servant, drawing the wrath of the noble's house.* |
+| 5 | You are accused of cheating. Whether the allegation is true or not, your reputation is tarnished.* |
+| 6 | You accidentally deliver a near-fatal wound to a foe. |
+
+**Might involve a rival*
+
+## Relaxation
+Sometimes the best use of downtime is doing nothing. Spend a workweek resting to automatically recover from the effects of long-term madness, reduce a level of exhaustion, and gain advantage on saving throws against disease or poison for the next workweek. No checks are required, though lingering threats could interrupt your peace.
+
+## Religious Service
+You devote a workweek to serving a temple or performing rites for your deity. After paying any necessary tithes, make a DC 10 ability check using Intelligence (Religion), Wisdom (Insight), or Charisma (Persuasion) as appropriate to the faith. Your check total determines how many favors you earn, which can later be called in for aid, though missteps can invite divine complications.
+### Religious Service
+| Check Total | Result |
+| --- | --- |
+| 1—10 | No effect. Your efforts fail to make a lasting impression. |
+| 11—20 | You earn one favor. |
+| 21+ | You earn two favors. |
+### Religious Service Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | You have offended a priest through your words or actions.* |
+| 2 | Blasphemy is still blasphemy, even if you did it by accident. |
+| 3 | A secret sect in the temple offers you membership. |
+| 4 | Another temple tries to recruit you as a spy.* |
+| 5 | The temple elders implore you to take up a holy quest. |
+| 6 | You accidentally discover that an important person in the temple is a fiend worshiper. |
+
+**Might involve a rival*
+
+## Research
+Delving into archives or questioning sages requires at least 1 workweek and 50 gp in expenses. Each additional 100 gp spent grants a +1 bonus to the effort. Make an Intelligence (Investigation) check to gauge how much lore you uncover, as noted on the outcomes table. Research can reveal multiple pieces of information but may also draw unwanted attention.
+### Research Outcomes
+| Check Total | Outcome |
+| --- | --- |
+| 1—5 | No effect. |
+| 6—10 | You learn one piece of lore. |
+| 11—20 | You learn two pieces of lore. |
+| 21+ | You learn three pieces of lore. |
+### Research Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | You accidentally damage a rare book. |
+| 2 | You offend a sage, who demands an extravagant gift.* |
+| 3 | If you had known that book was cursed, you never would have opened it. |
+| 4 | A sage becomes obsessed with convincing you of a number of strange theories about reality.* |
+| 5 | Your actions cause you to be banned from a library until you make reparations.* |
+| 6 | You uncovered useful lore, but only by promising to complete a dangerous task in return. |
+
+**Might involve a rival*
+
+## Scribing a Spell Scroll
+If you know a spell and have the requisite level, you can inscribe it onto a scroll. Spend the time and gold listed on the Spell Scroll Costs table and make an Arcana check with a DC equal to 10 + the spell’s level. On a failure, the materials are wasted. Success creates a scroll that others can cast once before it crumbles.
+### Spell Scroll Costs
+| Spell Level | Time | Cost |
+| --- | --- | --- |
+| Cantrip | 1 day | 15 gp |
+| 1st | 1 day | 25 gp |
+| 2nd | 3 days | 250 gp |
+| 3rd | 1 workweek | 500 gp |
+| 4th | 2 workweeks | 2,500 gp |
+| 5th | 4 workweeks | 5,000 gp |
+| 6th | 8 workweeks | 15,000 gp |
+| 7th | 16 workweeks | 25,000 gp |
+| 8th | 32 workweeks | 50,000 gp |
+| 9th | 48 workweeks | 250,000 gp |
+### Scribe a Scroll Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | You bought up the last of the rare ink used to craft scrolls, angering a wizard in town. |
+| 2 | The priest of a temple of good accuses you of trafficking in dark magic.* |
+| 3 | A wizard eager to collect one of your spells in a book presses you to sell the scroll. |
+| 4 | Due to a strange error in creating the scroll, it is instead a random spell of the same level. |
+| 5 | The rare parchment you bought for your scroll has a barely visible map on it. |
+| 6 | A thief attempts to break into your workroom.* |
+
+**Might involve a rival*
+
+## Selling a Magic Item
+Locating a buyer for a magic item requires 1 workweek and 25 gp to advertise. At the end of that time, make a Charisma (Persuasion) check. The check total indicates the offer you receive compared to the item’s base price, as shown on the table, and might also spark complications with rivals or interested factions.
+### Magic Item Base Prices
+| Rarity | Base Price* |
+| --- | --- |
+| Common | 100 gp |
+| Uncommon | 400 gp |
+| Rare | 4,000 gp |
+| Very rare | 40,000 gp |
+| Legendary | 200,000 gp |
+
+**Halved for a consumable item like a potion or scroll*
+### Magic Item Offer
+| Check Total | Offer |
+| --- | --- |
+| 1—10 | 50% of base price |
+| 11—20 | 100% of base price |
+| 21+ | 150% of base price |
+### Magic Item Sale Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | Your enemy secretly arranges to buy the item to use it against you.* |
+| 2 | A thieves' guild, alerted to the sale, attempts to steal your item.* |
+| 3 | A foe circulates rumors that your item is a fake.* |
+| 4 | A sorcerer claims your item as a birthright and demands you hand it over. |
+| 5 | Your item's previous owner, or surviving allies of the owner, vow to retake the item by force. |
+| 6 | The buyer is murdered before the sale is finalized.* |
+
+**Might involve a rival*
+
+## Training
+With access to a knowledgeable instructor, you can learn a language or gain proficiency with a set of tools. Training requires 10 workweeks of study and 25 gp per week to cover tuition and supplies. After the training period, you gain the new proficiency. Interruptions or lack of a teacher can extend the required time.
+### Training Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | Your instructor disappears, forcing you to spend one workweek finding a new one.* |
+| 2 | Your teacher instructs you in rare, archaic methods, which draw comments from others. |
+| 3 | Your teacher is a spy sent to learn your plans.* |
+| 4 | Your teacher is a wanted criminal. |
+| 5 | Your teacher is a cruel taskmaster. |
+| 6 | Your teacher asks for help dealing with a threat. |
+
+**Might involve a rival*
+
+## Work
+You can spend a workweek earning a living. The DM chooses an appropriate ability check, often tied to the job’s nature. Make the check and compare the result to the Wages table to see the lifestyle your earnings cover for that week. Complications on the job can reduce pay or draw you into local troubles.
+### Wages
+| Check Total | Earnings |
+| --- | --- |
+| 9 or lower | Poor lifestyle for the week |
+| 10—14 | Modest lifestyle for the week |
+| 15—20 | Comfortable lifestyle for the week |
+| 21+ | Comfortable lifestyle for the week + 25 gp |
+### Work Complications
+| d6 | Complication |
+| --- | --- |
+| 1 | A difficult customer or a fight with a coworker reduces the wages you earn by one category.* |
+| 2 | Your employer's financial difficulties result in your not being paid.* |
+| 3 | A coworker with ties to an important family in town takes a dislike to you.* |
+| 4 | Your employer is involved with a dark cult or a criminal enterprise. |
+| 5 | A crime ring targets your business for extortion.* |
+| 6 | You gain a reputation for laziness (unjustified or not, as you choose), giving you disadvantage on checks made for this downtime activity for the next six workweeks you devote to it.* |
+
+**Might involve a rival*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Resources:
       - NPC Names: resources/npc_names.md
       - DM Screen: resources/dm_screen.md
+      - Downtime: resources/downtime.md
       - Rules: resources/rules.md
       - Spells: resources/spells.md
       - Worldbuilding: resources/worldbuilding.md


### PR DESCRIPTION
## Summary
- add resource page summarizing downtime activities from *Xanathar's Guide to Everything* with full tables, rules, and complications
- link downtime page in site navigation

## Testing
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6894b68283488325afb5c992a9f5dc83