### PR TITLE
Fix MkDocs warnings and add missing indexes

### DIFF
--- a/docs/campaigns/index.md
+++ b/docs/campaigns/index.md
@@ -8,9 +8,9 @@ This section contains materials for all D&D campaigns.
 
 ## Active Campaigns
 
-- [The Last Whisper of Steel](tlwos/) - Current campaign
-- [The Shadow in the Empire](shadow-in-the-empire/) - New campaign
-- [Londra](londra/) - Campaign materials
+- [The Last Whisper of Steel](tlwos/index.md) - Current campaign
+- [The Shadow in the Empire](shadow-in-the-empire/index.md) - New campaign
+- [Londra](londra/index.md) - Campaign materials
 
 ## Campaign Archive
 

--- a/docs/campaigns/shadow-in-the-empire/encounters/index.md
+++ b/docs/campaigns/shadow-in-the-empire/encounters/index.md
@@ -1,0 +1,7 @@
+# Encounters Overview
+
+Reference material for encounter themes and regional context in The Shadow in the Empire.
+
+- [Q'Barra and Valenar frontier encounters](./qbarra-valenar-frontier-encounters.md)
+- [Destination encounter themes](./destination_encounter_themes.md)
+- [Valenar history](./valenar-history.md)

--- a/docs/campaigns/shadow-in-the-empire/exploration/encounters/hostile-factions/index.md
+++ b/docs/campaigns/shadow-in-the-empire/exploration/encounters/hostile-factions/index.md
@@ -1,0 +1,12 @@
+# Hostile Factions
+
+Frontier threats aligned with competing interests in the Shadow in the Empire campaign.
+
+- [Cannith scavenger team](./cannith-scavenger-team.md)
+- [Colonial bandits](./colonial-bandits.md)
+- [Dragonborn clan patrol](./dragonborn-clan-patrol.md)
+- [Exiled Brelish soldiers](./exiled-brelish-soldiers.md)
+- [Lizardfolk hunting party](./lizardfolk-hunting-party.md)
+- [Mercenary salvage crew](./mercenary-salvage-crew.md)
+- [Warforged free company](./warforged-free-company.md)
+- [Wyrm cult proselytizers](./wyrm-cult-proselytizers.md)

--- a/docs/campaigns/shadow-in-the-empire/exploration/encounters/index.md
+++ b/docs/campaigns/shadow-in-the-empire/exploration/encounters/index.md
@@ -1,0 +1,7 @@
+# Exploration Encounters
+
+Category overviews for encounters tied to the Q'Barra frontier.
+
+- [Hostile factions](./hostile-factions/index.md)
+- [Lost world discoveries](./lost-world/index.md)
+- [Wildlife](./wildlife/index.md)

--- a/docs/campaigns/shadow-in-the-empire/exploration/encounters/lost-world/index.md
+++ b/docs/campaigns/shadow-in-the-empire/exploration/encounters/lost-world/index.md
@@ -1,0 +1,12 @@
+# Lost World Discoveries
+
+Ancient sites and ruins awaiting discovery in Q'Barra.
+
+- [Ancient Gatekeeper menhir](./ancient-gatekeeper-menhir.md)
+- [Collapsed Cannith mining site](./collapsed-cannith-mining-site.md)
+- [Crashed Lyrandar airship](./crashed-lyrandar-airship.md)
+- [Draconic stone glyphs](./draconic-stone-glyphs.md)
+- [Overgrown Brelish outpost](./overgrown-brelish-outpost.md)
+- [Phosphorescent cavern](./phosphorescent-cavern.md)
+- [Ruined dragonshard temple](./ruined-dragonshard-temple.md)
+- [Vine-choked lizardfolk shrine](./vine-choked-lizardfolk-shrine.md)

--- a/docs/campaigns/shadow-in-the-empire/exploration/encounters/wildlife/index.md
+++ b/docs/campaigns/shadow-in-the-empire/exploration/encounters/wildlife/index.md
@@ -1,0 +1,12 @@
+# Wildlife Encounters
+
+Roaming beasts that can appear during wilderness travel.
+
+- [Basilisk](./basilisk.md)
+- [Giant constrictor snake](./giant-constrictor-snake.md)
+- [Hydra](./hydra.md)
+- [Jungle cat](./jungle-cat.md)
+- [Pteranodon flock](./pteranodon-flock.md)
+- [Spinosaurus](./spinosaurus.md)
+- [Swarm of stinging insects](./swarm-stinging-insects.md)
+- [Velociraptor pack](./velociraptor-pack.md)

--- a/docs/campaigns/shadow-in-the-empire/exploration/index.md
+++ b/docs/campaigns/shadow-in-the-empire/exploration/index.md
@@ -1,0 +1,9 @@
+# Exploration Overview
+
+A quick hub for the exploration materials tied to The Shadow in the Empire. Use these links to jump to the relevant encounter tables and regional notes while prepping sessions.
+
+- [Black Dawn exploration notes](./black_dawn_exploration.md)
+- [Q'Barra exploration guide](./qbarran_exploration.md)
+- [Q'Barra ruins exploration](./qbarran_exploration_ruins.md)
+- [Encounter statblocks](./encounter-statblocks.md)
+- [Exploration encounters](./encounters/index.md)

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,0 +1,13 @@
+# Resources
+
+Reference pages and tools for running games.
+
+- [NPC Names](./npc_names.md)
+- [DM Screen](./dm_screen.md)
+- [Downtime activities](./downtime.md)
+- [Rules reference](./rules.md)
+- [Spells](./spells.md)
+- [Bastions](./bastions.md)
+- [Worldbuilding guides](./worldbuilding.md)
+- [Tools](./tools/index.md)
+- [Tips](./tips.md)

--- a/docs/resources/spells.md
+++ b/docs/resources/spells.md
@@ -525,6 +525,7 @@ Areas of effect created by spells or other magic can't extend into the aura, and
 Ongoing spells, except those cast by an Artifact or a deity, are suppressed in the area. While an effect is suppressed, it doesn't function, but the time it spends suppressed counts against its duration.
 Dispel Magic has no effect on the aura, and the auras created by different Antimagic Field spells don't nullify each other.
 
+<a id="antipathy-sympathy"></a>
 ## Antipathy/Sympathy
 *Level:* Level 8 Enchantment
 *Casting Time:* 1 hour
@@ -767,6 +768,7 @@ You touch a creature, which must succeed on a Wisdom saving throw or become curs
 - If you deal damage to the target with an attack roll or a spell, the target takes an extra 1d8 Necrotic damage.
 **Using a Higher-Level Spell Slot.** If you cast this spell using a level 4 spell slot, you can maintain Concentration on it for up to 10 minutes. If you use a level 5+ spell slot, the spell doesn't require Concentration, and the duration becomes 8 hours (level 5-6 slot) or 24 hours (level 7-8 slot). If you use a level 9 spell slot, the spell lasts until dispelled.
 
+<a id="bigby-s-hand"></a>
 ## Bigby's Hand
 *Level:* Level 5 Evocation
 *Casting Time:* 1 action
@@ -839,6 +841,7 @@ Alternatively, target a nonmagical plant that isn't a creature, such as a tree o
 The target hit by the strike takes an extra 3d8 Radiant damage from the attack, and the target has the Blinded condition until the spell ends. At the end of each of its turns, the Blinded target makes a Constitution saving throw, ending the spell on itself on a success.
 **Using a Higher-Level Spell Slot.** The extra damage increases by 1d8 for each spell slot level above 3.
 
+<a id="blindness-deafness"></a>
 ## Blindness/Deafness
 *Level:* Level 2 Transmutation
 *Casting Time:* 1 action
@@ -1431,6 +1434,7 @@ One creature that you can see within range must succeed on a Wisdom saving throw
 A spectral crown appears on the Charmed target's head, and it must use its action before moving on each of its turns to make a melee attack against a creature other than itself that you mentally choose. The target can act normally on its turn if you choose no creature or if no creature is within its reach. The target repeats the save at the end of each of its turns, ending the spell on itself on a success.
 On your later turns, you must take the Magic action to maintain control of the target, or the spell ends.
 
+<a id="crusader-s-mantle"></a>
 ## Crusader's Mantle
 *Level:* Level 3 Evocation
 *Casting Time:* 1 action
@@ -1749,6 +1753,7 @@ You have a telepathic link with the Charmed target while the two of you are on t
 You can command the target to take a Reaction but must take your own Reaction to do so.
 **Using a Higher-Level Spell Slot.** Your Concentration can last longer with a spell slot of level 6 (up to 10 minutes), 7 (up to 1 hour), or 8+ (up to 8 hours).
 
+<a id="dragon-s-breath"></a>
 ## Dragon's Breath
 *Level:* Level 2 Transmutation
 *Casting Time:* 1 bonus action
@@ -1760,6 +1765,7 @@ You can command the target to take a Reaction but must take your own Reaction to
 You touch one willing creature, and choose Acid, Cold, Fire, Lightning, or Poison. Until the spell ends, the target can take a Magic action to exhale a 15-foot Cone. Each creature in that area makes a Dexterity saving throw, taking 3d6 damage of the chosen type on a failed save or half as much damage on a successful one.
 **Using a Higher-Level Spell Slot.** The damage increases by 1d6 for each spell slot level above 2.
 
+<a id="drawmij-s-instant-summons"></a>
 ## Drawmij's Instant Summons
 *Level:* Level 6 Conjuration
 *Casting Time:* 1 minute
@@ -1862,6 +1868,7 @@ You exert control over the elements, creating one of the following effects withi
 You touch a creature and choose Strength, Dexterity, Intelligence, Wisdom, or Charisma. For the duration, the target has Advantage on ability checks using the chosen ability.
 **Using a Higher-Level Spell Slot.** You can target one additional creature for each spell slot level above 2. You can choose a different ability for each target.
 
+<a id="enlarge-reduce"></a>
 ## Enlarge/Reduce
 *Level:* Level 2 Transmutation
 *Casting Time:* 1 action
@@ -1922,6 +1929,7 @@ When the spell ends, you return to the plane you left in the spot that correspon
 This spell ends instantly if you cast it while you are on the Ethereal Plane or a plane that doesn't border it, such as one of the Outer Planes.
 **Using a Higher-Level Spell Slot.** You can target up to three willing creatures (including yourself) for each spell slot level above 7. The creatures must be within 10 feet of you when you cast the spell.
 
+<a id="evard-s-black-tentacles"></a>
 ## Evard's Black Tentacles
 *Level:* Level 4 Conjuration
 *Casting Time:* 1 action
@@ -2693,6 +2701,7 @@ You open a gateway to the Far Realm, a region infested with unspeakable horrors.
 Any creature that starts its turn in the area takes 2d6 Cold damage. Any creature that ends its turn there must succeed on a Dexterity saving throw or take 2d6 Acid damage from otherworldly tentacles.
 **Using a Higher-Level Spell Slot.** The Cold or Acid damage (your choice) increases by 1d6 for each spell slot level above 3.
 
+<a id="hunter-s-mark"></a>
 ## Hunter's Mark
 *Level:* Level 1 Divination
 *Casting Time:* 1 bonus action
@@ -2826,6 +2835,7 @@ When the swarm appears, each creature in it makes a Constitution saving throw, t
 A creature you touch has the Invisible condition until the spell ends. The spell ends early immediately after the target makes an attack roll, deals damage, or casts a spell.
 **Using a Higher-Level Spell Slot.** You can target one additional creature for each spell slot level above 2.
 
+<a id="jallarzi-s-storm-of-radiance"></a>
 ## Jallarzi's Storm of Radiance
 *Level:* Level 5 Evocation
 *Casting Time:* 1 action
@@ -2874,6 +2884,7 @@ Name or describe a famous person, place, or object. The spell brings to your min
 The lore might consist of important details, amusing revelations, or even secret lore that has never been widely known. The more information you already know about the thing, the more precise and detailed the information you receive is. That information is accurate but might be couched in figurative language or poetry, as determined by the DM.
 If the famous thing you chose isn't actually famous, you hear sad musical notes played on a trombone, and the spell fails.
 
+<a id="leomund-s-secret-chest"></a>
 ## Leomund's Secret Chest
 *Level:* Level 4 Conjuration
 *Casting Time:* 1 action
@@ -2886,6 +2897,7 @@ You hide a chest and all its contents on the Ethereal Plane. You must touch the 
 While the chest remains on the Ethereal Plane, you can take a Magic action and touch the replica to recall the chest. It appears in an unoccupied space on the ground within 5 feet of you. You can send the chest back to the Ethereal Plane by taking a Magic action to touch the chest and the replica.
 After 60 days, there is a cumulative Effect continues chance at the end of each day that the spell ends. The spell also ends if you cast this spell again or if the Tiny replica chest is destroyed. If the spell ends and the larger chest is on the Ethereal Plane, the chest remains there for you or someone else to find.
 
+<a id="leomund-s-tiny-hut"></a>
 ## Leomund's Tiny Hut
 *Level:* Level 3 Evocation
 *Casting Time:* 1 minute
@@ -3170,6 +3182,7 @@ You step into a stone object or surface large enough to fully contain your body,
 While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with Disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use 5 feet of movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.
 Minor physical damage to the stone doesn't harm you, but its partial destruction or a change in its shape (to the extent that you no longer fit within it) expels you and deals 6d6 Force damage to you. The stone's complete destruction (or transmutation into a different substance) expels you and deals 50 Force damage to you. If expelled, you move into an unoccupied space closest to where you first entered and have the Prone condition.
 
+<a id="melf-s-acid-arrow"></a>
 ## Melf's Acid Arrow
 *Level:* Level 2 Evocation
 *Casting Time:* 1 action
@@ -3333,6 +3346,7 @@ A silvery beam of pale light shines down in a 5-foot-radius, 40-foot-high Cylind
 When the Cylinder appears, each creature in it makes a Constitution saving throw. On a failed save, a creature takes 2d10 Radiant damage, and if the creature is shape-shifted (as a result of the Polymorph spell, for example), it reverts to its true form and can't shape-shift until it leaves the Cylinder. On a successful save, a creature takes half as much damage only. A creature also makes this save when the spell's area moves into its space and when it enters the spell's area or ends its turn there. A creature makes this save only once per turn.
 **Using a Higher-Level Spell Slot.** The damage increases by 1d10 for each spell slot level above 2.
 
+<a id="mordenkainen-s-faithful-hound"></a>
 ## Mordenkainen's Faithful Hound
 *Level:* Level 4 Conjuration
 *Casting Time:* 1 action
@@ -3346,6 +3360,7 @@ No one but you can see the hound, and it is intangible and invulnerable. When a 
 At the start of each of your turns, the hound attempts to bite one enemy within 5 feet of it. That enemy must succeed on a Dexterity saving throw or take 4d8 Force damage.
 On your later turns, you can take a Magic action to move the hound up to 30 feet.
 
+<a id="mordenkainen-s-magnificent-mansion"></a>
 ## Mordenkainen's Magnificent Mansion
 *Level:* Level 7 Conjuration
 *Casting Time:* 1 minute
@@ -3360,6 +3375,7 @@ You can create any floor plan you like for the dwelling, but it can't exceed 50 
 A staff of 100 near-transparent servants attends all who enter. You determine the appearance of these servants and their attire. They are invulnerable and obey your commands. Each servant can perform tasks that a human could perform, but they can't attack or take any action that would directly harm another creature. Thus the servants can fetch things, clean, mend, fold clothes, light fires, serve food, pour wine, and so on. The servants can't leave the dwelling.
 When the spell ends, any creatures or objects left inside the extradimensional space are expelled into the unoccupied spaces nearest to the entrance.
 
+<a id="mordenkainen-s-private-sanctum"></a>
 ## Mordenkainen's Private Sanctum
 *Level:* Level 4 Abjuration
 *Casting Time:* 10 minute
@@ -3379,6 +3395,7 @@ When you cast the spell, you decide what sort of security the spell provides, ch
 Casting this spell on the same spot every day for 365 days makes the spell last until dispelled.
 **Using a Higher-Level Spell Slot.** You can increase the size of the Cube by 100 feet for each spell slot level above 4.
 
+<a id="mordenkainen-s-sword"></a>
 ## Mordenkainen's Sword
 *Level:* Level 7 Evocation
 *Casting Time:* 1 action
@@ -3414,6 +3431,7 @@ Similarly, this spell doesn't directly affect plant growth. The moved earth carr
 
 For the duration, you hide a target that you touch from Divination spells. The target can be a willing creature, or it can be a place or an object no larger than 10 feet in any dimension. The target can't be targeted by any Divination spell or perceived through magical scrying sensors.
 
+<a id="nystul-s-magic-aura"></a>
 ## Nystul's Magic Aura
 *Level:* Level 2 Illusion
 *Casting Time:* 1 action
@@ -3426,6 +3444,7 @@ With a touch, you place an illusion on a willing creature or an object that isn'
 **Mask (Creature).** Choose a creature type other than the target's actual type. Spells and other magical effects treat the target as if it were a creature of the chosen type.
 **False Aura (Object).** You change the way the target appears to spells and magical effects that detect magical auras, such as Detect Magic. You can make a nonmagical object appear magical, make a magic item appear nonmagical, or change the object's aura so that it appears to belong to a school of magic you choose.
 
+<a id="otiluke-s-freezing-sphere"></a>
 ## Otiluke's Freezing Sphere
 *Level:* Level 6 Evocation
 *Casting Time:* 1 action
@@ -3439,6 +3458,7 @@ If the globe strikes a body of water, it freezes the water to a depth of 6 inche
 You can refrain from firing the globe after completing the spell's casting. If you do so, a globe about the size of a sling bullet, cool to the touch, appears in your hand. At any time, you or a creature you give the globe to can throw the globe (to a range of 40 feet) or hurl it with a sling (to the sling's normal range). It shatters on impact, with the same effect as a normal casting of the spell. You can also set the globe down without shattering it. After 1 minute, if the globe hasn't already shattered, it explodes.
 **Using a Higher-Level Spell Slot.** The damage increases by 1d6 for each spell slot level above 6.
 
+<a id="otiluke-s-resilient-sphere"></a>
 ## Otiluke's Resilient Sphere
 *Level:* Level 4 Abjuration
 *Casting Time:* 1 action
@@ -3452,6 +3472,7 @@ Nothing—not physical objects, energy, or other spell effects—can pass throug
 The sphere is weightless and just large enough to contain the creature or object inside. An enclosed creature can take an action to push against the sphere's walls and thus roll the sphere at up to half the creature's Speed. Similarly, the globe can be picked up and moved by other creatures.
 A Disintegrate spell targeting the globe destroys it without harming anything inside.
 
+<a id="otto-s-irresistible-dance"></a>
 ## Otto's Irresistible Dance
 *Level:* Level 6 Enchantment
 *Casting Time:* 1 action
@@ -3793,6 +3814,7 @@ The creature returns to life with 1 Hit Point. This spell also neutralizes any p
 This spell closes all mortal wounds, but it doesn't restore missing body parts. If the creature is lacking body parts or organs integral for its survival—its head, for instance—the spell automatically fails.
 Coming back from the dead is an ordeal. The target takes a -4 penalty to D20 Tests. Every time the target finishes a Long Rest, the penalty is reduced by 1 until it becomes 0.
 
+<a id="rary-s-telepathic-bond"></a>
 ## Rary's Telepathic Bond
 *Level:* Level 5 Divination
 *Casting Time:* 1 action
@@ -4565,6 +4587,7 @@ Once triggered, the glyph glows, filling a 60-foot-radius Sphere with Dim Light 
 You cause psychic energy to erupt at a point within range. Each creature in a 20-foot-radius Sphere centered on that point makes an Intelligence saving throw, taking 8d6 Psychic damage on a failed save or half as much damage on a successful one.
 On a failed save, a target also has muddled thoughts for 1 minute. During that time, it subtracts 1d6 from all its attack rolls and ability checks, as well as any Constitution saving throws to maintain Concentration. The target makes an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success.
 
+<a id="tasha-s-bubbling-cauldron"></a>
 ## Tasha's Bubbling Cauldron
 *Level:* Level 6 Conjuration
 *Casting Time:* 1 action
@@ -4577,6 +4600,7 @@ You conjure a claw-footed cauldron filled with bubbling liquid. The cauldron app
 The liquid in the cauldron duplicates the properties of a Common or an Uncommon potion of your choice (such as a Potion of Healing). As a Bonus Action, you or an ally can reach into the cauldron and withdraw one potion of that kind. The potion is contained in a vial that disappears when the potion is consumed. The cauldron can produce a number of these potions equal to your spellcasting ability modifier (minimum 1). When the last of these potions is withdrawn from the cauldron, the cauldron disappears, and the spell ends.
 Potions obtained from the cauldron that aren't consumed disappear when you cast this spell again.
 
+<a id="tasha-s-hideous-laughter"></a>
 ## Tasha's Hideous Laughter
 *Level:* Level 1 Enchantment
 *Casting Time:* 1 action
@@ -4657,6 +4681,7 @@ Many major temples, guildhalls, and other important places have permanent telepo
 When you first gain the ability to cast this spell, you learn the sigil sequences for two destinations on the Material Plane, determined by the DM. You might learn additional sigil sequences during your adventures. You can commit a new sigil sequence to memory after studying it for 1 minute.
 You can create a permanent teleportation circle by casting this spell in the same location every day for 365 days.
 
+<a id="tenser-s-floating-disk"></a>
 ## Tenser's Floating Disk
 *Level:* Level 1 Conjuration
 *Casting Time:* 1 action
@@ -5105,6 +5130,7 @@ You must designate a location, such as a temple, as a sanctuary by casting this 
 The target takes an extra 1d6 Necrotic damage from the attack, and it must succeed on a Wisdom saving throw or have the Frightened condition until the spell ends. At the end of each of its turns, the Frightened target repeats the save, ending the spell on itself on a success.
 **Using a Higher-Level Spell Slot.** The damage increases by 1d6 for each spell slot level above 1.
 
+<a id="yolande-s-regal-presence"></a>
 ## Yolande's Regal Presence
 *Level:* Level 5 Enchantment
 *Casting Time:* 1 action


### PR DESCRIPTION
## Summary
- add index pages for exploration and encounter content in The Shadow in the Empire campaign
- create a resources landing page and update campaign links to point directly at index files
- add explicit anchors to spell entries to resolve table-of-contents warnings during the build

## Testing
- mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693491d897908325a894f00178f085ff)