### PR TITLE
Add road ambush opener for TLWOS session 018

### DIFF
--- a/docs/campaigns/tlwos/session-018-tea-house-tithe.md
+++ b/docs/campaigns/tlwos/session-018-tea-house-tithe.md
@@ -1,0 +1,95 @@
+---
+title: "TLWOS Session 018 – Tea House Tithe"
+tags:
+  - tlwos
+  - session-notes
+  - arc-2
+  - takashima
+  - twice-cursed-samurai
+---
+
+## Arc Position
+- **Arc:** 2 — Takashima Front
+- **Session Number:** 018 (first session of the arc)
+- **Base of Operations:** Takashima Fortress City (refugee quarter near the southern gates)
+
+## Session Overview
+On the road from Nagano to Takashima, the party stumbles onto a lacquer-slick killing ground: four travelers torn apart and a six-armed troll looming over Iseri, who is unconscious and bound in resin strands. This ambush tees up the cost of Lady Arashi’s neglect before the party even sees Takashima’s gates. Surviving the road hazard leads into the city’s pressure cooker of refugees, ration lines, and the Dust Petal Tea House summons from the Twice-Cursed Samurai, who offers intel and aid—but only if the party steals the miracle ledger tying Lady Arashi to Obsidian Circle smuggling.
+
+## Strong Start Options (Wednesday opener)
+- **Six-Arm Road Ambush (default):** _Six chitinous arms crank a prayer wheel made of bones as a troll hoists Iseri’s limp form. Black resin bandages her torso; the troll hums a broken shrine song and snaps its mandibles toward the party. Four bodies hang from lacquered branches, each clutching a different shrine token._ → Immediate combat/skill split: free Iseri before she takes death save failures; optional flashback to how she got snared (failed scout roll, cursed milepost?)
+- **Tea House Ultimatum (if the road is skipped):** _Steam curls off cracked teacups as masked patrols drag a street-preacher into the mud outside. Inside, the ronin kneels alone beneath a shrine of guttering candles, steel mask resting on the tatami. His curse bleeds black lacquer across the floorboards as he rasps: “Takashima rots from within. Help me carve out the infection—and I will help you cleanse your shrines.”_ → He slides a new missive onto the table: an Obsidian Circle resupply slips through the southern gate at dusk.
+- **Gate Stampede:** Refugees surge as gate inspectors sound an alarm; a Circle courier tries to burn his ledger to avoid capture. The party can intervene, grab the courier, or ride the chaos to slip beyond the walls.
+- **Shrine Dawn Failure:** At first light the warding bells stutter and a sheet of black lacquer rain falls over the shrine quarter. Spirits wail as magic fizzles. Immediate skill challenge to stabilize a warded shrine; reward favor with shrine wardens.
+
+## Major Beats & Outcomes (last session recap)
+- **Dust Petal Parley:** Negotiated terms with the Twice-Cursed Samurai; he admitted killing Master Hideo on Lady Arashi’s orders but swore to expose her Circle ties. Party accepted the job to recover Arashi’s miracle ledger from the Silk Ledger Guildhall.
+- **City Texture:** Witnessed shrine wardens struggling with failing rituals; Fox’s prayer faltered, confirming the arc theme of dwindling magic. Shigeo brokered food for refugees, earning quiet goodwill.
+- **Stealth Ledger Heist:** Infiltrated the guildhall during a midnight accounting shift. Kanji and Yasei used festival masks to slip past guards while Thornbringer’s druidcraft muffled the windows. Aoshi neutralized a Circle scribe branded with obsidian prayer beads.
+- **Evidence Secured:** Retrieved the miracle ledger detailing Arashi’s payments to Circle couriers and a manifest of shrine reagents bound for “Project Heirloom.” Captured scribe revealed code phrases for Circle dead-drops in the shrine quarter.
+- **Ronin’s Aid Unlocked:** Delivered the ledger to the ronin; he provided a cache of silent-step tabi (+1 Stealth) and a password for passing through his covert tunnel to the outer walls.
+
+## Scene Options (pick 2–3 beats for Wednesday)
+- **Roadside Recovery:** Secure Iseri, interrogate the troll’s shrine tokens, and track whether the victims were couriers or refugees. Clue: one token bears Arashi’s crest scorched black.
+- **Gate Interdiction:** Intercept the Obsidian Circle resupply at the southern gate; choices: stealth swap crates, intimidate officials, or cut a deal with the desperate inspector on duty.
+- **Dead-Drop Gamble:** Use the phrases (“the wind carries lacquer” / “the lacquer cracks at dusk”) to plant false orders that redirect Circle operatives into an ambush near the shrine quarter.
+- **Shrine Triage:** Help wardens stabilize a sputtering shrine; skill challenge with corruption risks that foreshadow Project Heirloom’s drain.
+- **Tunnel Crawl:** Traverse the ronin’s covert tunnel to the Okugōri; hazards include collapsing masonry, lacquer seep, and blind oni catfish.
+- **Court Intrigue:** Present or threaten to leak the ledger to rival magistrates; social contest reveals Arashi’s next move and potential allies.
+
+## Character Review (PCs)
+- **Kanji:** Masked infiltrator; excels at deception and disguise. Give chances to exploit festival masks and bureaucratic loopholes.
+- **Yasei:** Agile scout; likes rooftop angles. Offer vertical paths during gate or tunnel scenes.
+- **Thornbringer:** Nature/druidcraft; can muffle, root, or cleanse lacquer corruption. Spotlight during shrine triage.
+- **Aoshi:** Precise striker; effective at neutralizing key targets. Set up a single high-value Circle courier or lacquer spawn to shut down.
+- **Fox:** Spiritual connection; prayers faltering. Let Fox sense the kami’s pain and gain visions about Project Heirloom.
+- **Shigeo:** Quartermaster/face; good with supplies and people. Tie him to refugee morale and negotiations with inspectors.
+
+## Relevant Foes & Challenges
+- **Six-Arm Lacquer Troll (opener boss):** Multi-grapple plus resin restrain; lashes out with bone prayer wheel (disadvantage aura on Concentration saves if within 10 ft). Regeneration only halted by fire/radiant or breaking the lacquer prayer wheel.
+- **Obsidian Circle Couriers (skirmishers):** Poisoned knives, smoke pellets, panic button (signal flare that calls 1d2 reinforcements if not silenced).
+- **Gate Inspectors (neutral, swayable):** Start cautious; can become allies if protected or bribed with food slips.
+- **Lacquer Wraith (hazard for shrine triage):** Uses grapple + corrosive drain; becomes vulnerable if blessed water or druidcraft cleanses lacquer coating.
+- **Blind Oni Catfish (tunnel beast):** Burrows through wet stone; low-light blindsight, hates bright flame or thunder damage.
+
+## Key NPCs in Play
+- **Iseri:** Found unconscious and resin-bound by the six-arm troll; waking her yields fragmented visions of a cursed milepost humming with lacquer.
+- **Twice-Cursed Samurai (ally/patron):** Curse worsens when he lies; can provide covert tunnel access and pressure on Arashi’s guards.
+- **Lady Arashi (off-screen antagonist):** Project Heirloom architect; wants to present “miracles” to keep power. Will retaliate if ledger leaks.
+- **Kazuo Himura (refugee retainer):** Knows which inspectors are bribeable; fears Arashi but respects the party’s mercy.
+- **Whisper-Book Scribe (prisoner/contact):** Has dead-drop phrasing and knows Circle couriers’ shift rotations; can be coerced or turned.
+
+## Fantastic Locations
+- **Nagano–Takashima Forest Road:** Cursed mileposts ooze lacquer; trees hung with bone prayer wheels; a shallow ravine offers partial cover against the troll’s reach.
+- **Takashima Southern Gate:** Four-tiered checkpoint with brass prayer wheels, incense braziers, and refugee cattle-chutes; under each platform run lacquer-streaked sluices feeding the undercaverns.
+- **Dust Petal Tea House (safe meet):** Candlelit shrine alcove, lacquer-stained tatami, hidden trapdoor to the ronin’s tunnel.
+- **Shrine Quarter Wards:** Cracked jade bells, rain of black lacquer at dawn, kami visages flickering in puddles that whisper bargains.
+- **Under-gate Caverns:** Flooded maintenance shafts beneath the gate; echoing water, blind oni catfish, and forgotten shrine plaques that can be used as cover or leverage.
+
+## Treasure & Boons
+- **Troll Salvage:** Bone prayer wheel (counts as holy symbol; shatters to suppress regeneration in a 10-ft aura for 1 minute, single use), resin cords (50 gp; advantage on one grapple check when used as fetters).
+- **Circle Resupply Crates:** Smoke pellets, obsidian prayer beads worth 50 gp each, 1–2 vials of shadow-ink (advantage on a single Stealth check in dim light).
+- **Shrine Favor:** Blessing of the Bell—once per day, one PC can reroll a failed Wisdom save against fear or charm until corruption is cleansed.
+- **Gate Inspector’s Ledger:** Contains names of bribed officials; leverage for court intrigue or blackmail.
+- **Tunnel Cache (ronin):** Spare silent-step tabi pair or lacquer-eater salve (neutralizes one lacquer-based hazard on contact).
+
+## NPCs Featured
+- **Twice-Cursed Samurai:** Now a reluctant patron; curse worsens when he lies, giving the party a leverage point.
+- **Kazuo Himura:** Lady Arashi’s retainer, hiding among refugees; confirmed Arashi’s private audiences with Circle envoys.
+- **“Whisper-Book” Scribe:** Low-level Circle operative captured at the guildhall; knows dead-drop phrases and believes the boy heir is already “anointed.”
+
+## Discoveries & Clues
+- Lady Arashi funds falsified miracles through Silk Ledger intermediaries.
+- “Project Heirloom” requires shrine reagents being redirected away from Takashima’s failing wardings.
+- Circle dead-drops in the shrine quarter use the phrase “the wind carries lacquer” for pickup, “the lacquer cracks at dusk” for delivery.
+- Shrine wardens report spells sputtering at dawn, implying the kami drain is accelerating.
+
+## Rewards & Mechanics
+- **Silent-Step Tabi:** Treated as light footwear that grants advantage on the first Stealth check made each infiltration scene (once per scene).
+- **Cache Refill:** Minor healing herbs replenished; each character starts next session with one free use of a common healing kit.
+
+## Threads for Next Session
+- Use the dead-drop phrases to plant forged instructions and misdirect Circle couriers.
+- Decide whether to expose Arashi publicly or trade the ledger to a rival faction in Takashima’s court.
+- Investigate the shrine reagent manifests to locate “Project Heirloom” and the boy heir’s current hiding place.
+- Explore the ronin’s tunnel to the outer walls to reach the Okugōri without alerting the city guard.


### PR DESCRIPTION
## Summary
- set a six-arm lacquer troll ambush with Iseri as the default Wednesday opener on the road from Nagano to Takashima
- expand scenes, foes, NPCs, locations, and rewards to support the new road encounter while retaining Takashima follow-on beats

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935eb96bacc83259812ad9864bc4563)