### PR TITLE
Move Arc 2 opening into session notes

### DIFF
--- a/docs/posts/Arc 2 Opening.md
+++ b/docs/posts/Arc 2 Opening.md
@@ -1,3 +1,10 @@
+---
+title: "TLWoS: Arc 2 Opening – Road to Takashima"
+date: 2025-11-26
+tags: [tlwos, arc-2, session, takashima]
+summary: "Session-ready beats for launching Arc 2 on the road to Takashima."
+---
+
 # Arc 2 Opening: The Road to Takashima
 
 ## Session Setup


### PR DESCRIPTION
## Summary
- move the Arc 2 opening content into the Session Notes/posts area alongside existing Londra notes
- add blog front matter with tlwos tags, date, and summary so it renders like other session posts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938dc97bcfc8325a1bcfbfd3fd73e4c)